### PR TITLE
fix: :bug: Fix bug regarding the activation of the iceServer 

### DIFF
--- a/pymediasoup/handlers/aiortc_handler.py
+++ b/pymediasoup/handlers/aiortc_handler.py
@@ -7,6 +7,7 @@ from aiortc import (
     RTCSessionDescription,
     RTCRtpTransceiver,
     MediaStreamTrack,
+    RTCConfiguration
 )
 import sdp_transform
 from .sdp import common_utils
@@ -165,7 +166,10 @@ class AiortcHandler(HandlerInterface):
                 "video", options.extendedRtpCapabilities
             ),
         }
-        self._pc = RTCPeerConnection()
+
+        configuration = RTCConfiguration(iceServers=iceServers)
+           
+        self._pc = RTCPeerConnection(configuration=configuration)
 
         @self._pc.on("iceconnectionstatechange")
         def on_iceconnectionstatechange():

--- a/pymediasoup/handlers/handler_interface.py
+++ b/pymediasoup/handlers/handler_interface.py
@@ -52,7 +52,7 @@ class HandlerInterface(EnhancedEventEmitter):
         dtlsParameters: DtlsParameters,
         extendedRtpCapabilities: ExtendedRtpCapabilities,
         sctpParameters: Optional[SctpParameters] = None,
-        iceServers: Optional[RTCIceServer] = None,
+        iceServers: Optional[List[RTCIceServer]] = None,
         iceTransportPolicy: Optional[Literal["all", "relay"]] = None,
         additionalSettings: Optional[Any] = None,
         proprietaryConstraints: Optional[Any] = None,

--- a/pymediasoup/models/handler_interface.py
+++ b/pymediasoup/models/handler_interface.py
@@ -26,7 +26,7 @@ class HandlerRunOptions(BaseModel):
     iceCandidates: List[IceCandidate]
     dtlsParameters: DtlsParameters
     sctpParameters: Optional[SctpParameters]
-    iceServers: Optional[RTCIceServer]
+    iceServers: Optional[List[RTCIceServer]]
     iceTransportPolicy: Optional[Literal["all", "relay"]]
     additionalSettings: Optional[Any]
     proprietaryConstraints: Optional[Any]


### PR DESCRIPTION
The activation of the iceServer in the transports was being affected by an incorrect type definition in the handler_interface. Additionally, the iceServer was not being passed as a configuration parameter when instantiating the RTCPeerConnection to be used in the creation of the RTCIceGatherer.

Regards..!