### PR TITLE
fix: remove redundant code that removes listener causing error

### DIFF
--- a/pymediasoup/consumer.py
+++ b/pymediasoup/consumer.py
@@ -202,6 +202,4 @@ class Consumer(EnhancedEventEmitter):
         if not self._track:
             return
 
-        self._track.remove_listener("ended", self._onTrackEnded)
-
         self._track.stop()

--- a/pymediasoup/consumer.py
+++ b/pymediasoup/consumer.py
@@ -202,4 +202,7 @@ class Consumer(EnhancedEventEmitter):
         if not self._track:
             return
 
-        self._track.stop()
+        try:
+            self._track.stop()
+        except Exception:
+            pass


### PR DESCRIPTION
This code here is causes to throw error just after removing this ended listener, inside _track.stop(), it emits `ended` which causes to throw error.

This remove track listener is not required as already within track.stop() all the listeners are removed after emitting ended. 